### PR TITLE
Fix compatibility with kirkstone branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "honister"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "honister kirkstone"

--- a/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
+++ b/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
@@ -14,5 +14,11 @@ do_install() {
 
 FILES:${PN} += " /init /media/rfs"
 
+QA_EMPTY_DIRS:remove = "/media"
+QA_EMPTY_DIRS:append = " \
+    /media/rfs/ro \
+    /media/rfs/rw \
+"
+
 # Due to kernel dependency
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
This should fix compatibility with the kirkstone branch, while maintaining compatibility with honister.

It's up to you whether a new "kirkstone" branch deserves to be created in the current repo too.

Also, since the "empty-dirs" QA feature seems to have been backported to "honister" branch too in [2], it would be a good idea to cherry-pick this to the existing "honister" branch as well.

[2] https://github.com/openembedded/openembedded-core/commit/9f3fbfc02ae6fadffbcc1bda1fa75dfe140d05c5