### PR TITLE
Add overlaymodule to boot command line

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -61,6 +61,9 @@ read_args() {
 				ROOT_RWRESET=$optarg ;;
 			rootrwoptions=*)
 				ROOT_RWMOUNTOPTIONS_DEVICE="$optarg" ;;
+			overlayfstype=*)
+				modprobe "$optarg" 2> /dev/null || \
+					log "Could not load $optarg module";;
 			init=*)
 			INIT=$optarg ;;
 		esac


### PR DESCRIPTION
This adds overlaymodule to the boot command line so if the overlay filesystem you want to use was built as a module it can get loaded before it needs to be checked.  This only loads the module, similar to what rootrofstype and rootrwfstype do.