### PR TITLE
Branch improvements

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -30,7 +30,7 @@ early_setup() {
 	mkdir -p /proc
 	mkdir -p /sys
 	$MOUNT -t proc proc /proc
-	$MOUNT -t sysfs sysfs /sys
+	grep -w "/sys" /proc/mounts >/dev/null || $MOUNT -t sysfs sysfs /sys
 	grep -w "/dev" /proc/mounts >/dev/null || $MOUNT -t devtmpfs none /dev
 }
 


### PR DESCRIPTION
First commit
On my machine /sys was already mounted which create an issue, i done the same trick used for /dev

Second commit:
The device naming may vary according to the device/machine. This commit allow to use PARTLABEL=partname in root= and rootrw=

