### PR TITLE
Execute preinit before mount points are moved

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -207,6 +207,11 @@ mount_and_boot() {
 			;;
 	esac
 
+    # Execute any preinit scripts
+	if [ -x "${PREINIT}" ]; then
+        ${PREINIT}
+	fi
+
 	# Move read-only and read-write root file system into the overlay
 	# file system
 	mkdir -p $ROOT_MOUNT/$ROOT_ROMOUNT $ROOT_MOUNT/$ROOT_RWMOUNT
@@ -217,10 +222,6 @@ mount_and_boot() {
 	$MOUNT -n --move /sys ${ROOT_MOUNT}/sys
 	$MOUNT -n --move /dev ${ROOT_MOUNT}/dev
 
-    # Execute any preinit scripts
-	if [ -x "${PREINIT}" ]; then
-        ${PREINIT}
-	fi
 
 	cd $ROOT_MOUNT
 


### PR DESCRIPTION
Some applications may need those mounts to work properly.