### PR TITLE
fix usage of ROOT_RWDEVICE in case of no rw device

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -172,10 +172,9 @@ mount_and_boot() {
 	# Build mount options for read write root file system.
 	# If a read-write device was specified via kernel command line, use
 	# it, otherwise default to tmpfs.
-	ROOT_RWDEVICE=$(resolve_device "$ROOT_RWDEVICE")
-	wait_for_device "${ROOT_RWDEVICE}"
 	if [ -n "${ROOT_RWDEVICE}" ]; then
-
+	        ROOT_RWDEVICE=$(resolve_device "$ROOT_RWDEVICE")
+		wait_for_device "${ROOT_RWDEVICE}"
 		ROOT_RWMOUNTPARAMS="-o $ROOT_RWMOUNTOPTIONS_DEVICE $ROOT_RWDEVICE"
 		if [ -n "${ROOT_RWFSTYPE}" ]; then
 			ROOT_RWMOUNTPARAMS="-t $ROOT_RWFSTYPE $ROOT_RWMOUNTPARAMS"


### PR DESCRIPTION
if ROOT_RWDEVICE is empty, i.e. no device specified in the kernel commandline, the script has waited for no device to appear and then exited