### PR TITLE
Add new support for custom uppdir locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you use this layer you do *not* need to set `read-only-rootfs` in the
 ## Kernel command line parameters
 
 These examples are not meant to be complete. They just contain parameters that
-are used by the initscript of this repository. Some additional paramters might
+are used by the initscript of this repository. Some additional parameters might
 be necessary.
 
 ### Example using initrd:

--- a/README.md
+++ b/README.md
@@ -166,3 +166,6 @@ Defaults to `rw,noatime,mode=755`.
 
 `rootrwreset=` set to `yes` if you want to delete all the files in the
 read-write file system prior to building the overlay root files system.
+
+`rootrwupperdir=` specifies a custom rootrw upperdir name under overlayfs.
+Defaults to `upperdir`.

--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -18,6 +18,7 @@ ROOT_RWDEVICE=""
 ROOT_ROMOUNT="/media/rfs/ro"
 ROOT_RWMOUNT="/media/rfs/rw"
 ROOT_RWRESET="no"
+ROOT_RWUPPERDIR="upperdir"
 
 ROOT_ROFSTYPE=""
 ROOT_ROMOUNTOPTIONS="bind"
@@ -66,6 +67,8 @@ read_args() {
 				probe_fs "$optarg" ;;
 			rootrwreset=*)
 				ROOT_RWRESET=$optarg ;;
+			rootrwupperdir=*)
+				ROOT_RWUPPERDIR=$optarg ;;
 			rootrwoptions=*)
 				ROOT_RWMOUNTOPTIONS_DEVICE="$optarg" ;;
 			overlayfstype=*)
@@ -216,11 +219,11 @@ mount_and_boot() {
 	# Create/Mount overlay root file system
 	case $union_fs_type in
 		"overlay")
-			mkdir -p $ROOT_RWMOUNT/upperdir $ROOT_RWMOUNT/work
+			mkdir -p $ROOT_RWMOUNT/$ROOT_RWUPPERDIR $ROOT_RWMOUNT/work
 			$MOUNT -t overlay overlay \
 				-o "$(printf "%s%s%s" \
 					"lowerdir=$ROOT_ROMOUNT," \
-					"upperdir=$ROOT_RWMOUNT/upperdir," \
+					"upperdir=$ROOT_RWMOUNT/$ROOT_RWUPPERDIR," \
 					"workdir=$ROOT_RWMOUNT/work")" \
 				$ROOT_MOUNT
 			;;


### PR DESCRIPTION
This is to make it possible for user to define their own `upperdir` location in rootrw.
This gives the user more control over the `upperdir`(s) and the possibility to manage multiple versions of `upperdir` on their own.