### PR TITLE
Support initramfs-framework

### DIFF
--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://init-readonly-rootfs-overlay-boot.sh"
+
+S = "${WORKDIR}"
+
+do_install:append() {
+    install -d ${D}/init.d
+    install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init.d/91-overlayroot
+}
+


### PR DESCRIPTION
Allowing to use this script inside the initramfs-framework which can be usefull in order to mix overlay feature with other features like:
- lvm
- cryptfs
- ...

Replace initramfs-module-overlayroot default script by this one