### PR TITLE
Master+update layerseries compat

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "scarthgap"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "walnascar whinlatter wrynose"

--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -2,10 +2,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://init-readonly-rootfs-overlay-boot.sh"
 
-S = "${WORKDIR}"
-
 do_install:append() {
     install -d ${D}/init.d
-    install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init.d/91-overlayroot
+    install -m 0755 ${UNPACKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init.d/91-overlayroot
 }
 

--- a/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
+++ b/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
@@ -4,10 +4,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 DEPENDS = "virtual/kernel"
 SRC_URI = "file://init-readonly-rootfs-overlay-boot.sh"
 
-S = "${WORKDIR}"
-
 do_install() {
-        install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init
+        install -m 0755 ${UNPACKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init
         install -d "${D}/media/rfs/ro"
         install -d "${D}/media/rfs/rw"
 }


### PR DESCRIPTION
1. WORKDIR -> UNPACK dir changes for Yocto releases past scarthgap Yocto 5.0

2. layer.conf: Add LAYERSERIES_COMPAT_readonly_rootfs_overlay so that the layer used for post scarthgap builds.

3. layer.conf: Remove scarthgap from LAYERSERIES_COMPAT_readonly_rootfs_overlay since the WORKDIR to UNPACKDIR changes are not backward compatible with scarthgap.