### PR TITLE
readonly-rootfs-overlay-init-script / init-readonly-rootfs-overlay-boot: UNPACKDIR changes + script syntax fix (and spacing)

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -50,15 +50,15 @@ read_args() {
 		ROOT_RWDEVICE=${bootparam_rootrw}
 	fi
 	if [ ! -z "${bootparam_rootrwfstype+x}" ]; then
-		ROOT_RWFSTYPE=$bootparam_rootrwfstype}
+		ROOT_RWFSTYPE=${bootparam_rootrwfstype}
 		load_kernel_module ${bootparam_rootrwfstype}
 	fi
 	if [ ! -z "${bootparam_rootrwreset+x}" ]; then
 		ROOT_RWRESET=${bootparam_rootrwreset}
 	fi
-        if [ ! -z "${bootparam_rootrwupperdir+x}" ]; then
-                ROOT_RWUPPERDIR=${bootparam_rootrwupperdir}
-        fi
+	if [ ! -z "${bootparam_rootrwupperdir+x}" ]; then
+		ROOT_RWUPPERDIR=${bootparam_rootrwupperdir}
+	fi
 	if [ ! -z "${bootparam_rootrwoptions+x}" ]; then
 		ROOT_RWMOUNTOPTIONS_DEVICE=${bootparam_rootrwoptions}
 	fi

--- a/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
+++ b/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
@@ -4,6 +4,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 DEPENDS = "virtual/kernel"
 SRC_URI = "file://init-readonly-rootfs-overlay-boot.sh"
 
+S = "${UNPACKDIR}"
+
 do_install() {
         install -m 0755 ${UNPACKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init
         install -d "${D}/media/rfs/ro"


### PR DESCRIPTION
Some notes: 
- Was getting this warning when modifying recipes via devtool (which resulted in an empty source directory when running devtool modify) - adding `S = "${UNPACKDIR}"` fixes this issue: 
```
WARNING: initramfs-readonly-rootfs-overlay: the directory ${UNPACKDIR}/${BP} (/home/yoctouser/yocto-workspace/master-vcu/build/tmp/work/vcu-oe-linux/initramfs-readonly-rootfs-overlay/1.0/devtooltmp-02v3x9ig/workdir/sources/initramfs-readonly-rootfs-overlay-1.0) pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked to
```

- Noticed a missing bracket in the init-readonly-rootfs-overlay-boot.sh script + fixed some spacing. 
