### PR TITLE
initrdscripts: use switch_root instead of chroot

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -245,16 +245,13 @@ mount_and_boot() {
 	$MOUNT -n --move $ROOT_ROMOUNT ${ROOT_MOUNT}/$ROOT_ROMOUNT
 	$MOUNT -n --move $ROOT_RWMOUNT ${ROOT_MOUNT}/$ROOT_RWMOUNT
 
-	$MOUNT -n --move /proc ${ROOT_MOUNT}/proc
-	$MOUNT -n --move /sys ${ROOT_MOUNT}/sys
-	$MOUNT -n --move /dev ${ROOT_MOUNT}/dev
-
-
-	cd $ROOT_MOUNT
+	umount /proc 2>/dev/null || true
+	umount /sys  2>/dev/null || true
+	umount /dev  2>/dev/null || true
 
 	# switch to actual init in the overlay root file system
-	exec chroot $ROOT_MOUNT "$INIT" ||
-		fatal "Couldn't chroot, dropping to shell"
+	exec switch_root "${ROOT_MOUNT}" "$INIT" ||
+		fatal "Couldn't switch_root, dropping to shell"
 }
 
 mount_and_boot


### PR DESCRIPTION
## Problem

`exec chroot` keeps the initramfs tmpfs mounted as a shadow rootfs under the new PID 1. This causes container runtimes (e.g. Docker, nerdctl) to fail when executing processes inside containers:

```
Error response from daemon: cannot exec in a stopped state: unknown
```

The root cause is that the stale initramfs mount leaks into new mount namespaces created by the container runtime, confusing namespace resolution for `exec`.

## Fix

Replace `exec chroot` with `exec switch_root`, which uses `pivot_root` to properly replace the rootfs for PID 1 and removes the old initramfs from the mount tree entirely.

Since `switch_root` does not carry over existing mounts from the old root, `/proc`, `/sys` and `/dev` are unmounted before calling it so they are re-mounted cleanly by the new init (systemd or sysvinit).

## Testing

Tested on an x86-64 target running Yocto scarthgap with Docker and nerdctl. Container `exec` works correctly after this change.

```
/ # docker exec -it mycontainer sh
# (works)
```